### PR TITLE
Update FlysystemAssetStore.php

### DIFF
--- a/src/Flysystem/FlysystemAssetStore.php
+++ b/src/Flysystem/FlysystemAssetStore.php
@@ -55,7 +55,7 @@ class FlysystemAssetStore extends SS_FlysystemAssetStore
 
 
             list($width, $height, $type, $attr) = getimagesize($path);
-
+            $img = null;
             switch ($type) {
                 case 2:
                     $img = imagecreatefromjpeg($path);
@@ -67,7 +67,11 @@ class FlysystemAssetStore extends SS_FlysystemAssetStore
                     imagewebp($img, $this->createWebPName($orgpath), $this->webp_quality);
 
             }
-            imagedestroy($img);
+            if($img != null)
+            {
+                imagedestroy($img);
+            }
+            
         }
     }
 


### PR DESCRIPTION
prevents ServerError when uploading gifs because the case is not included and $img is null